### PR TITLE
Output 3D-URG pointcloud as frame with interlace of 2

### DIFF
--- a/launch/rsj_pointcloud_to_laserscan_3durg.launch
+++ b/launch/rsj_pointcloud_to_laserscan_3durg.launch
@@ -10,7 +10,8 @@
         <rosparam>
             ip: 192.168.0.10
             range_min: 0.0
-            output_cycle: field
+            output_cycle: frame
+            interlace: 2
         </rosparam>
 
     </node>


### PR DESCRIPTION
field単位でのpublishだと、スカスカでクラスタリング時に、小さなクラスタがたくさんできてしまうので、frame単位にするのが良いと思います。(少し離れたところに、検出したいサイズと近いクラスタがたくさんできてしまう場合がある。)
ただし、インタレース4回だとpublish周期が5Hzになり、ちょっと見劣りするのでインタレース2回にしています。(会場で要調整)

現実的な使い方では、座標変換の都合line周期でpublishし、ユーザプログラム側で必要な時間分蓄積して使うことになるので、口頭ででも説明があると良いと思います。